### PR TITLE
nonNegativeInteger datatype recognition

### DIFF
--- a/src/plaza/rdf/implementations/common.clj
+++ b/src/plaza/rdf/implementations/common.clj
@@ -46,6 +46,7 @@
         (= "float" (.toLowerCase (keyword-to-string lit))) XSDDatatype/XSDfloat
         (= "int" (.toLowerCase (keyword-to-string lit))) XSDDatatype/XSDint
         (= "integer" (.toLowerCase (keyword-to-string lit))) XSDDatatype/XSDinteger
+        (= "nonnegativeinteger" (.toLowerCase (keyword-to-string lit))) XSDDatatype/XSDnonNegativeInteger
         (= "long" (.toLowerCase (keyword-to-string lit))) XSDDatatype/XSDlong
         (= "string" (.toLowerCase (keyword-to-string lit))) XSDDatatype/XSDstring
         :else (make-custom-type literal)))))
@@ -70,6 +71,7 @@
          "float" (keyword lit)
          "int" (keyword lit)
          "integer" (keyword lit)
+         "nonNegativeInteger" (keyword lit)
          "long" (keyword lit)
          "string" (keyword lit)
          nil))))

--- a/src/plaza/rdf/implementations/sesame.clj
+++ b/src/plaza/rdf/implementations/sesame.clj
@@ -43,6 +43,7 @@
         (= "float" (.toLowerCase (keyword-to-string lit))) "http://www.w3.org/2001/XMLSchema#float"
         (= "int" (.toLowerCase (keyword-to-string lit))) "http://www.w3.org/2001/XMLSchema#int"
         (= "integer" (.toLowerCase (keyword-to-string lit))) "http://www.w3.org/2001/XMLSchema#integer"
+        (= "nonnegativeinteger" (.toLowerCase (keyword-to-string lit))) "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
         (= "long" (.toLowerCase (keyword-to-string lit))) "http://www.w3.org/2001/XMLSchema#long"
         (= "string" (.toLowerCase (keyword-to-string lit))) "http://www.w3.org/2001/XMLSchema#string"
         :else literal))))
@@ -61,6 +62,7 @@
       (= "http://www.w3.org/2001/XMLSchema#float" (str (.getDatatype lit))) (.floatValue lit)
       (= "http://www.w3.org/2001/XMLSchema#int" (str (.getDatatype lit))) (.intValue lit)
       (= "http://www.w3.org/2001/XMLSchema#integer" (str (.getDatatype lit))) (.integerValue lit)
+      (= "http://www.w3.org/2001/XMLSchema#nonNegativeInteger" (str (.getDatatype lit))) (.integerValue lit)
       (= "http://www.w3.org/2001/XMLSchema#long" (str (.getDatatype lit))) (.longValue lit)
       (= "http://www.w3.org/2001/XMLSchema#string" (str (.getDatatype lit))) (.stringValue lit)
       true (.stringValue lit))))


### PR DESCRIPTION
XSD's `nonNegativeInteger` datatype was not supported and when parsing document with such datatype, and then working with it's triples would give following exception (Jena backend):

```
java.lang.RuntimeException: java.lang.IllegalArgumentException: No matching field found: lexicalValue for class java.lang.Integer
```

Simple example:

File: `simple.rdf`

```
<rdf:RDF
  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
  xmlns:j.0="http://test.com/" > 
  <rdf:Description rdf:about="http://test.com/a">
    <j.0:b rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">1</j.0:b>
  </rdf:Description>
</rdf:RDF>
```

test:

```
(def model (document-to-model (java.io.FileInputStream. "simple.rdf") :xml))
(def triples (model-to-triples model))
(count triples)
=> Exception
```
